### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,6 @@ Universal Core REST service for Questions and Surveys.
     :target: https://coveralls.io/r/universalcore/unicore.ask?branch=develop
     :alt: Code Coverage
 
-.. image:: https://pypip.in/version/unicore.ask/badge.svg
+.. image:: https://img.shields.io/pypi/v/unicore.ask.svg
     :target: https://pypi.python.org/pypi/unicore.ask
     :alt: Pypi Package


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20unicore-ask))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `unicore-ask`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.